### PR TITLE
feat: adaptive reveal styles and personalized goal tracking (v1.0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/user-event": "^14.6.1",
         "autoprefixer": "^10.4.21",
         "chart.js": "^4.5.0",
+        "d3-delaunay": "^6.0.4",
         "postcss-import": "^16.1.1",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -2467,6 +2468,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2522,6 +2535,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -4938,6 +4960,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.46.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "habit-hive",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@testing-library/user-event": "^14.6.1",
     "autoprefixer": "^10.4.21",
     "chart.js": "^4.5.0",
+    "d3-delaunay": "^6.0.4",
     "postcss-import": "^16.1.1",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/src/components/HabitTracker.jsx
+++ b/src/components/HabitTracker.jsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 import MosaicReveal from "./MosaicReveal";
+import PizzaReveal from "./PizzaReveal";
+import VoronoiReveal from "./VoronoiReveal";
+import { loadRevealStyle } from "../utils/localStorage";
 
 const HabitTracker = ({
   entries,
@@ -9,7 +12,7 @@ const HabitTracker = ({
   entryLabel,
   placeholder,
   unit,
-  mosaicGridSize = 4,
+  goal = 16,
   inspoQuote,
   clearWarning = "Are you sure you want to clear all your data? This cannot be undone.",
 }) => {
@@ -96,12 +99,22 @@ const HabitTracker = ({
                 </span>
               </div>
             </div>
-            <MosaicReveal
-              imageSrc={imageSrc}
-              filledSquares={entries.length}
-              onComplete={() => setTimeout(() => setShowMosaic(false), 3000)}
-              gridSize={mosaicGridSize}
-            />
+            {(() => {
+              const style = loadRevealStyle();
+              const revealProps = {
+                imageSrc,
+                filledSquares: entries.length,
+                goal,
+              };
+              if (style === "pizza") return <PizzaReveal {...revealProps} />;
+              if (style === "voronoi") return <VoronoiReveal {...revealProps} />;
+              return (
+                <MosaicReveal
+                  {...revealProps}
+                  onComplete={() => setTimeout(() => setShowMosaic(false), 3000)}
+                />
+              );
+            })()}
             <div className="text-yellow-400 text-sm">
               Keep building your hive! 🐝
             </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,7 +3,15 @@ import NavBar from "./NavBar";
 const Header = () => {
   return (
     <header className="text-center py-8 pb-4 bg-black border-b-5 border-yellow-400">
-      <h1 className="text-5xl tracking-wider m-0">🐝 Habit Hive</h1>
+      <div className="flex items-center justify-center gap-3">
+        <h1 className="text-5xl tracking-wider m-0">🐝 Habit Hive</h1>
+        <span
+          className="text-xs font-bold px-2 py-1 rounded-full border border-yellow-400 text-yellow-400 tracking-widest"
+          title="Professionally tested on at least two computers"
+        >
+          v1.0.2
+        </span>
+      </div>
       <p className="text-white mt-2">
         Track your coding hours and build your hive!
       </p>

--- a/src/components/MosaicReveal.jsx
+++ b/src/components/MosaicReveal.jsx
@@ -1,5 +1,33 @@
 import React, { useState, useEffect } from "react";
-import beehive from "../assets/beehive.png"; // Adjust the path as necessary
+import beehive from "../assets/beehive.png";
+
+// Aim for ~3 tiles per row, max 4 per row, max 4 rows. Fuller rows at top.
+function getRowCounts(n) {
+  if (n <= 0) return [1];
+  const numRows = Math.min(Math.ceil(n / 3), 4);
+  const base = Math.floor(n / numRows);
+  const extras = n % numRows;
+  const rows = Array(numRows).fill(base);
+  for (let i = 0; i < extras; i++) rows[i]++;
+  return rows;
+}
+
+function getTileStyle(isRevealed, imageSrc, rowIndex, colIndex, countInRow, numRows) {
+  if (!isRevealed) {
+    return { opacity: 0.3, transition: "opacity 0.3s ease-in-out" };
+  }
+  const xPos = countInRow > 1 ? (colIndex / (countInRow - 1)) * 100 : 0;
+  const yPos = numRows > 1 ? (rowIndex / (numRows - 1)) * 100 : 0;
+  return {
+    backgroundImage: `url(${imageSrc})`,
+    backgroundSize: `${countInRow * 100}% ${numRows * 100}%`,
+    backgroundPosition: `${xPos}% ${yPos}%`,
+    backgroundRepeat: "no-repeat",
+    opacity: 1,
+    transition: "opacity 0.3s ease-in-out",
+    filter: "blur(3px)",
+  };
+}
 
 const MosaicReveal = ({
   imageSrc,
@@ -8,73 +36,38 @@ const MosaicReveal = ({
   gridSize = 4,
   goal,
 }) => {
+  const totalSquares = goal ?? gridSize * gridSize;
+  const rowCounts = getRowCounts(totalSquares);
+  const numRows = rowCounts.length;
+  const showFullImage = filledSquares >= totalSquares;
   const [revealedSquares, setRevealedSquares] = useState([]);
-  const totalSquares = gridSize * gridSize;
-  const completionTarget = goal ?? totalSquares;
-  const showFullImage = filledSquares >= completionTarget;
 
   useEffect(() => {
-    const newRevealedSquares = [];
+    const revealed = [];
     for (let i = 0; i < Math.min(filledSquares, totalSquares); i++) {
-      newRevealedSquares.push(i);
+      revealed.push(i);
     }
-    setRevealedSquares(newRevealedSquares);
-
-    if (filledSquares >= completionTarget && onComplete) {
+    setRevealedSquares(revealed);
+    if (filledSquares >= totalSquares && onComplete) {
       setTimeout(onComplete);
     }
-  }, [filledSquares, totalSquares, completionTarget, onComplete]);
+  }, [filledSquares, totalSquares, onComplete]);
 
-  const getSquareStyle = (index) => {
-    const isRevealed = revealedSquares.includes(index);
-
-    if (isRevealed) {
-      // Calculate the position of this square in the image
-      const row = Math.floor(index / gridSize);
-      const col = index % gridSize;
-      const sizePercent = 100 / gridSize;
-
-      return {
-        backgroundImage: `url(${imageSrc})`,
-        backgroundSize: `${gridSize * 100}%`,
-        backgroundPosition: `${col * sizePercent}% ${row * sizePercent}%`,
-        backgroundRepeat: "no-repeat",
-        opacity: 1,
-        transition: "opacity 0.3s ease-in-out, filter 0.3s ease-in-out",
-        width: "100%",
-        height: "100%",
-        minHeight: "40px",
-        filter: "blur(3px)", // Add blur to revealed squares
-      };
-    }
-
-    return {
-      opacity: 0.3,
-      transition: "opacity 0.3s ease-in-out, filter 0.3s ease-in-out",
-      width: "100%",
-      height: "100%",
-      minHeight: "40px", // Ensure minimum size for visibility
-    };
-  };
-
-  // If showing full image, render the complete unblurred image
   if (showFullImage) {
     return (
       <div className="relative w-full max-w-md mx-auto">
         <div
           className="w-full rounded-lg bg-cover bg-center"
-          style={{
-            backgroundImage: `url(${imageSrc})`,
-            aspectRatio: "1/1",
-          }}
+          style={{ backgroundImage: `url(${imageSrc})`, aspectRatio: "1/1" }}
         />
       </div>
     );
   }
 
+  let tileIndex = 0;
+
   return (
     <div className="relative w-full max-w-md mx-auto">
-      {/* Background image (full image) */}
       <div
         className="absolute inset-0 bg-cover bg-center rounded-lg"
         style={{
@@ -82,35 +75,44 @@ const MosaicReveal = ({
           filter: "blur(4px) brightness(0.3)",
         }}
       />
-
-      {/* Mosaic grid */}
       <div
-        className="relative grid gap-1 rounded-lg overflow-hidden"
+        className="mosaic-grid relative rounded-lg overflow-hidden"
         style={{
-          gridTemplateColumns: `repeat(${gridSize}, 1fr)`,
+          display: "flex",
+          flexDirection: "column",
           aspectRatio: "1/1",
           width: "100%",
+          gap: "4px",
         }}
       >
-        {Array.from({ length: totalSquares }, (_, index) => (
-          <div
-            key={index}
-            className="bg-gray-800 border border-gray-600 rounded-sm flex items-center justify-center"
-            style={getSquareStyle(index)}
-          />
+        {rowCounts.map((count, rowIndex) => (
+          <div key={rowIndex} style={{ display: "flex", flex: 1, gap: "4px" }}>
+            {Array.from({ length: count }, (_, colIndex) => {
+              const i = tileIndex++;
+              return (
+                <div
+                  key={i}
+                  className="bg-gray-800 border border-gray-600 rounded-sm"
+                  style={{
+                    flex: 1,
+                    ...getTileStyle(
+                      revealedSquares.includes(i),
+                      imageSrc,
+                      rowIndex,
+                      colIndex,
+                      count,
+                      numRows
+                    ),
+                  }}
+                />
+              );
+            })}
+          </div>
         ))}
       </div>
-
-      {/* Progress indicator */}
       <div className="absolute bottom-2 right-2 bg-black/70 text-white px-2 py-1 rounded text-sm">
-        {filledSquares}/{completionTarget}
+        {filledSquares}/{totalSquares}
       </div>
-      {/* Completion count indicator */}
-      {filledSquares === completionTarget && (
-        <div className="absolute top-2 right-2 bg-blue-600/90 text-white px-2 py-1 rounded text-xs">
-          {filledSquares}/{completionTarget}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/MosaicReveal.jsx
+++ b/src/components/MosaicReveal.jsx
@@ -6,24 +6,24 @@ const MosaicReveal = ({
   filledSquares = 0,
   onComplete,
   gridSize = 4,
+  goal,
 }) => {
   const [revealedSquares, setRevealedSquares] = useState([]);
   const totalSquares = gridSize * gridSize;
-  const showFullImage = filledSquares >= 16;
+  const completionTarget = goal ?? totalSquares;
+  const showFullImage = filledSquares >= completionTarget;
 
   useEffect(() => {
-    // Update revealed squares based on filledSquares prop
     const newRevealedSquares = [];
     for (let i = 0; i < Math.min(filledSquares, totalSquares); i++) {
       newRevealedSquares.push(i);
     }
     setRevealedSquares(newRevealedSquares);
 
-    // Call onComplete when all squares are filled
-    if (filledSquares >= totalSquares && onComplete) {
+    if (filledSquares >= completionTarget && onComplete) {
       setTimeout(onComplete);
     }
-  }, [filledSquares, totalSquares, onComplete]);
+  }, [filledSquares, totalSquares, completionTarget, onComplete]);
 
   const getSquareStyle = (index) => {
     const isRevealed = revealedSquares.includes(index);
@@ -103,12 +103,12 @@ const MosaicReveal = ({
 
       {/* Progress indicator */}
       <div className="absolute bottom-2 right-2 bg-black/70 text-white px-2 py-1 rounded text-sm">
-        {filledSquares}/{totalSquares}
+        {filledSquares}/{completionTarget}
       </div>
       {/* Completion count indicator */}
-      {filledSquares === totalSquares && (
+      {filledSquares === completionTarget && (
         <div className="absolute top-2 right-2 bg-blue-600/90 text-white px-2 py-1 rounded text-xs">
-          {filledSquares}/16
+          {filledSquares}/{completionTarget}
         </div>
       )}
     </div>

--- a/src/components/MosaicReveal.test.jsx
+++ b/src/components/MosaicReveal.test.jsx
@@ -42,15 +42,18 @@ describe("MosaicReveal", () => {
     const { container } = render(
       <MosaicReveal imageSrc={mockImageSrc} filledSquares={20} gridSize={4} />,
     );
-    const revealedSquares = container.querySelectorAll('[style*="opacity: 1"]');
-    expect(revealedSquares).toHaveLength(16); // Should cap at total squares
+    // When filledSquares exceeds totalSquares, the full image is shown instead
+    const fullImage = container.querySelector(".bg-cover.bg-center");
+    expect(fullImage).toBeInTheDocument();
+    const squares = container.querySelectorAll(".bg-gray-800");
+    expect(squares).toHaveLength(0);
   });
 
   it("maintains aspect ratio with different grid sizes", () => {
     const { container } = render(
       <MosaicReveal imageSrc={mockImageSrc} gridSize={3} />,
     );
-    const grid = container.querySelector(".grid");
+    const grid = container.querySelector(".mosaic-grid");
     expect(grid).toHaveStyle({
       aspectRatio: "1/1",
     });
@@ -132,13 +135,13 @@ describe("MosaicReveal", () => {
     );
     expect(backgroundDiv.style.filter).to.equal("blur(4px) brightness(0.3)");
   });
-  it("displays completion count indicator when completionCount > 0", () => {
+  it("displays progress indicator with correct count", () => {
     const { container } = render(
-      <MosaicReveal imageSrc={mockImageSrc} completionCount={5} />,
+      <MosaicReveal imageSrc={mockImageSrc} filledSquares={5} />,
     );
 
-    const completionIndicator = container.querySelector(".bg-blue-600\\/90");
-    expect(completionIndicator).toHaveTextContent("5/16");
+    const progressIndicator = container.querySelector(".bg-black\\/70");
+    expect(progressIndicator).toHaveTextContent("5/16");
   });
 
   it("does not display completion count indicator when completionCount is 0", () => {
@@ -150,35 +153,21 @@ describe("MosaicReveal", () => {
     expect(completionIndicator).not.toBeInTheDocument();
   });
 
-  it("shows full unblurred image when completionCount >= 16", () => {
+  it("shows full unblurred image when all squares are filled", () => {
     const { container } = render(
-      <MosaicReveal
-        imageSrc={mockImageSrc}
-        completionCount={16}
-        filledSquares={10}
-      />,
+      <MosaicReveal imageSrc={mockImageSrc} filledSquares={16} />,
     );
 
-    // Should not render mosaic grid
+    // Mosaic grid should not render
     const squares = container.querySelectorAll(".bg-gray-800");
-    expect(squares).toHaveLength(16);
+    expect(squares).toHaveLength(0);
 
-    // Should render full image
+    // Full image should render
     const fullImage = container.querySelector(".bg-cover.bg-center");
     expect(fullImage).toHaveStyle({
       backgroundImage: `url(${mockImageSrc})`,
       aspectRatio: "1/1",
     });
-
-    // Should show unlocked badge
-    const unlockedBadge = container.querySelector(".bg-green-600\\/90");
-    expect(unlockedBadge).toBeInTheDocument();
-    expect(unlockedBadge).toHaveTextContent("Unlocked!");
-
-    // Should still show progress indicator
-    const progressIndicator = container.querySelector(".bg-black\\/70");
-    expect(progressIndicator).toBeInTheDocument();
-    expect(progressIndicator).toHaveTextContent("10/16");
   });
 
   it("shows full unblurred image when completionCount > 16", () => {
@@ -217,7 +206,7 @@ describe("MosaicReveal", () => {
 
   it("maintains aspect ratio for full image view", () => {
     const { container } = render(
-      <MosaicReveal imageSrc={mockImageSrc} completionCount={16} />,
+      <MosaicReveal imageSrc={mockImageSrc} filledSquares={16} />,
     );
 
     const fullImage = container.querySelector(".bg-cover.bg-center");

--- a/src/components/PizzaReveal.jsx
+++ b/src/components/PizzaReveal.jsx
@@ -1,0 +1,136 @@
+import React from "react";
+import beehive from "../assets/beehive.png";
+
+const TWO_PI = 2 * Math.PI;
+const SIZE = 300;
+
+const norm = (a) => ((a % TWO_PI) + TWO_PI) % TWO_PI;
+
+const boundaryPoint = (cx, cy, half, theta) => {
+  const dx = Math.sin(theta);
+  const dy = -Math.cos(theta);
+  let best = Infinity;
+
+  const check = (t, perp) => {
+    if (t > 1e-10 && Math.abs(perp) <= half + 1e-10 && t < best) best = t;
+  };
+
+  if (Math.abs(dx) > 1e-10) {
+    check(half / dx, dy * (half / dx));
+    check(-half / dx, dy * (-half / dx));
+  }
+  if (Math.abs(dy) > 1e-10) {
+    check(half / dy, dx * (half / dy));
+    check(-half / dy, dx * (-half / dy));
+  }
+
+  return { x: cx + dx * best, y: cy + dy * best };
+};
+
+// Corners in clockwise-from-top order with their angles and relative positions
+const CORNERS = [
+  { theta: Math.PI / 4,     rel: [1, -1] }, // top-right
+  { theta: 3 * Math.PI / 4, rel: [1,  1] }, // bottom-right
+  { theta: 5 * Math.PI / 4, rel: [-1, 1] }, // bottom-left
+  { theta: 7 * Math.PI / 4, rel: [-1,-1] }, // top-left
+];
+
+const slicePolygon = (cx, cy, half, startAngle, endAngle) => {
+  const span = norm(endAngle - startAngle);
+  const corners = CORNERS
+    .filter(c => norm(c.theta - startAngle) < span - 1e-10)
+    .sort((a, b) => norm(a.theta - startAngle) - norm(b.theta - startAngle))
+    .map(c => ({ x: cx + c.rel[0] * half, y: cy + c.rel[1] * half }));
+
+  return [
+    { x: cx, y: cy },
+    boundaryPoint(cx, cy, half, startAngle),
+    ...corners,
+    boundaryPoint(cx, cy, half, endAngle),
+  ];
+};
+
+const toPointsStr = (points) =>
+  points.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" ");
+
+const PizzaReveal = ({ imageSrc, filledSquares = 0, goal = 8 }) => {
+  const cx = SIZE / 2, cy = SIZE / 2, half = SIZE / 2;
+
+  const slices = React.useMemo(() => {
+    const step = TWO_PI / goal;
+    return Array.from({ length: goal }, (_, i) => {
+      const start = norm(i * step);
+      const end = norm((i + 1) * step);
+      return toPointsStr(slicePolygon(cx, cy, half, start, end));
+    });
+  }, [goal]);
+
+  if (filledSquares >= goal) {
+    return (
+      <div className="relative w-full max-w-md mx-auto">
+        <div
+          className="w-full rounded-lg bg-cover bg-center"
+          style={{ backgroundImage: `url(${imageSrc})`, aspectRatio: "1/1" }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full max-w-md mx-auto" style={{ aspectRatio: "1/1" }}>
+      <svg
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        className="w-full h-full rounded-lg overflow-hidden"
+        style={{ display: "block" }}
+      >
+        <defs>
+          {/* Background: blur + darken */}
+          <filter id={`pz-bg-${goal}`}>
+            <feGaussianBlur stdDeviation="4" result="blurred" />
+            <feColorMatrix in="blurred" type="matrix"
+              values="0.3 0 0 0 0  0 0.3 0 0 0  0 0 0.3 0 0  0 0 0 1 0" />
+          </filter>
+          {/* Revealed pieces: blur only */}
+          <filter id={`pz-rev-${goal}`} x="-5%" y="-5%" width="110%" height="110%">
+            <feGaussianBlur stdDeviation="3" />
+          </filter>
+          {slices.map((_, i) => (
+            <clipPath key={i} id={`pz-${goal}-${i}`}>
+              <polygon points={slices[i]} />
+            </clipPath>
+          ))}
+        </defs>
+
+        {/* Blurry darkened beehive background */}
+        <image href={beehive} x={0} y={0} width={SIZE} height={SIZE}
+          filter={`url(#pz-bg-${goal})`} />
+
+        {/* Semi-transparent overlay on unrevealed slices */}
+        {slices.map((pointsStr, i) => i >= filledSquares && (
+          <polygon key={`u-${i}`} points={pointsStr} fill="rgba(17,24,39,0.65)" />
+        ))}
+
+        {/* Revealed slices: clip group first, then blur image inside */}
+        {slices.slice(0, filledSquares).map((_, i) => (
+          <g key={i} clipPath={`url(#pz-${goal}-${i})`}>
+            <image href={imageSrc} x={0} y={0} width={SIZE} height={SIZE}
+              filter={`url(#pz-rev-${goal})`} />
+          </g>
+        ))}
+
+        {/* Slice borders */}
+        {slices.map((pointsStr, i) => (
+          <polygon key={i} points={pointsStr} fill="none"
+            stroke="#ca8a04" strokeWidth="1" opacity="0.5" />
+        ))}
+
+        <rect x={SIZE - 64} y={SIZE - 28} width={60} height={22} rx={3} fill="rgba(0,0,0,0.75)" />
+        <text x={SIZE - 34} y={SIZE - 13} textAnchor="middle" fill="white" fontSize="11" fontFamily="monospace">
+          {filledSquares}/{goal}
+        </text>
+      </svg>
+    </div>
+  );
+};
+
+export default PizzaReveal;

--- a/src/components/VoronoiReveal.jsx
+++ b/src/components/VoronoiReveal.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { Delaunay } from "d3-delaunay";
+import beehive from "../assets/beehive.png";
+
+const SIZE = 300;
+
+// Seeded random number generator (mulberry32)
+const mulberry32 = (seed) => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+const jitteredPoints = (n, w, h, rand) => {
+  const cols = Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
+  const cw = w / cols;
+  const ch = h / rows;
+  const pts = [];
+  for (let r = 0; r < rows && pts.length < n; r++) {
+    for (let c = 0; c < cols && pts.length < n; c++) {
+      pts.push([(c + 0.2 + rand() * 0.6) * cw, (r + 0.2 + rand() * 0.6) * ch]);
+    }
+  }
+  return pts;
+};
+
+const shuffle = (arr, rand) => {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+};
+
+const toPointsStr = (polygon) =>
+  polygon.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+
+const VoronoiReveal = ({ imageSrc, filledSquares = 0, goal = 8 }) => {
+  const cells = React.useMemo(() => {
+    const rand = mulberry32(goal * 1337 + 42);
+    const points = jitteredPoints(goal, SIZE, SIZE, rand);
+    const delaunay = Delaunay.from(points);
+    const voronoi = delaunay.voronoi([0, 0, SIZE, SIZE]);
+
+    const polygons = Array.from({ length: goal }, (_, i) => voronoi.cellPolygon(i))
+      .filter(Boolean)
+      .map((p, i) => ({ id: i, pointsStr: toPointsStr(p) }));
+
+    // Shuffle reveal order so it looks organic, not top-to-bottom
+    return shuffle(polygons, mulberry32(goal * 7919 + 13));
+  }, [goal]);
+
+  if (filledSquares >= goal) {
+    return (
+      <div className="relative w-full max-w-md mx-auto">
+        <div
+          className="w-full rounded-lg bg-cover bg-center"
+          style={{ backgroundImage: `url(${imageSrc})`, aspectRatio: "1/1" }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full max-w-md mx-auto" style={{ aspectRatio: "1/1" }}>
+      <svg
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        className="w-full h-full rounded-lg overflow-hidden"
+        style={{ display: "block" }}
+      >
+        <defs>
+          {/* Background: blur + darken */}
+          <filter id={`vr-bg-${goal}`}>
+            <feGaussianBlur stdDeviation="4" result="blurred" />
+            <feColorMatrix in="blurred" type="matrix"
+              values="0.3 0 0 0 0  0 0.3 0 0 0  0 0 0.3 0 0  0 0 0 1 0" />
+          </filter>
+          {/* Revealed pieces: blur only */}
+          <filter id={`vr-rev-${goal}`} x="-5%" y="-5%" width="110%" height="110%">
+            <feGaussianBlur stdDeviation="3" />
+          </filter>
+          {cells.map(cell => (
+            <clipPath key={cell.id} id={`vr-${goal}-${cell.id}`}>
+              <polygon points={cell.pointsStr} />
+            </clipPath>
+          ))}
+        </defs>
+
+        {/* Blurry darkened beehive background */}
+        <image href={beehive} x={0} y={0} width={SIZE} height={SIZE}
+          filter={`url(#vr-bg-${goal})`} />
+
+        {/* Semi-transparent overlay on unrevealed cells */}
+        {cells.map((cell, i) => i >= filledSquares && (
+          <polygon key={`u-${cell.id}`} points={cell.pointsStr} fill="rgba(17,24,39,0.65)" />
+        ))}
+
+        {/* Revealed cells: clip group first, then blur image inside */}
+        {cells.slice(0, filledSquares).map(cell => (
+          <g key={cell.id} clipPath={`url(#vr-${goal}-${cell.id})`}>
+            <image href={imageSrc} x={0} y={0} width={SIZE} height={SIZE}
+              filter={`url(#vr-rev-${goal})`} />
+          </g>
+        ))}
+
+        {/* Cell borders */}
+        {cells.map(cell => (
+          <polygon key={cell.id} points={cell.pointsStr} fill="none"
+            stroke="#ca8a04" strokeWidth="1" opacity="0.5" />
+        ))}
+
+        <rect x={SIZE - 64} y={SIZE - 28} width={60} height={22} rx={3} fill="rgba(0,0,0,0.75)" />
+        <text x={SIZE - 34} y={SIZE - 13} textAnchor="middle" fill="white" fontSize="11" fontFamily="monospace">
+          {filledSquares}/{goal}
+        </text>
+      </svg>
+    </div>
+  );
+};
+
+export default VoronoiReveal;

--- a/src/routes/CodingTracker.jsx
+++ b/src/routes/CodingTracker.jsx
@@ -1,5 +1,6 @@
 import HabitTracker from "../components/HabitTracker";
 import programmingBee from "../assets/programmingBee.jpg";
+import { loadGoals } from "../utils/localStorage";
 
 const codingConfig = {
   title: "Your Coding Hive",
@@ -7,14 +8,21 @@ const codingConfig = {
   entryLabel: "How many hours did you code?",
   placeholder: "e.g. 2.5",
   unit: "h",
-  mosaicGridSize: 4,
   clearWarning:
     "Are you sure you want to clear all your coding data? This cannot be undone.",
   inspoQuote: "You've been a busy coding bee!",
 };
 
-const CodingTracker = ({ entries, setEntries }) => (
-  <HabitTracker entries={entries} setEntries={setEntries} {...codingConfig} />
-);
+const CodingTracker = ({ entries, setEntries }) => {
+  const goal = loadGoals().coding;
+  return (
+    <HabitTracker
+      entries={entries}
+      setEntries={setEntries}
+      goal={goal}
+      {...codingConfig}
+    />
+  );
+};
 
 export default CodingTracker;

--- a/src/routes/Dashboard.jsx
+++ b/src/routes/Dashboard.jsx
@@ -1,30 +1,23 @@
 import React from "react";
 import MosaicReveal from "../components/MosaicReveal";
+import PizzaReveal from "../components/PizzaReveal";
+import VoronoiReveal from "../components/VoronoiReveal";
 import WelcomeLanding from "../components/WelcomeLanding";
 import programmingBee from "../assets/programmingBee.jpg";
 import flashdanceBee from "../assets/flashdanceBee.jpg";
 import meditatingBee from "../assets/meditatingBee.jpg";
-import { loadAllEntries } from "../utils/localStorage";
+import { loadAllEntries, loadGoals, saveGoals, loadRevealStyle, saveRevealStyle } from "../utils/localStorage";
+
+const STYLE_OPTIONS = [
+  { id: "grid",    label: "Grid"   },
+  { id: "pizza",   label: "Pizza"  },
+  { id: "voronoi", label: "Puzzle" },
+];
 
 const HABIT_CATEGORIES = [
-  {
-    name: "Coding",
-    key: "coding",
-    image: programmingBee,
-    goal: 16,
-  },
-  {
-    name: "Physical Health",
-    key: "physical",
-    image: flashdanceBee,
-    goal: 16,
-  },
-  {
-    name: "Mental Health",
-    key: "mental",
-    image: meditatingBee,
-    goal: 16,
-  },
+  { name: "Coding", key: "coding", image: programmingBee },
+  { name: "Physical Health", key: "physical", image: flashdanceBee },
+  { name: "Mental Health", key: "mental", image: meditatingBee },
 ];
 
 // FIXED: Regular function (React.memo is for components, not functions)
@@ -109,6 +102,21 @@ const Dashboard = ({
   const [habitData, setHabitData] = React.useState(() => getHabitData());
   const [recentActivity, setRecentActivity] = React.useState([]);
   const [isLoading, setIsLoading] = React.useState(false);
+  const [goals, setGoals] = React.useState(() => loadGoals());
+  const [revealStyle, setRevealStyle] = React.useState(() => loadRevealStyle());
+
+  const handleGoalChange = React.useCallback((key, newGoal) => {
+    setGoals((prev) => {
+      const updated = { ...prev, [key]: newGoal };
+      saveGoals(updated);
+      return updated;
+    });
+  }, []);
+
+  const handleStyleChange = React.useCallback((style) => {
+    setRevealStyle(style);
+    saveRevealStyle(style);
+  }, []);
 
   // OPTIMIZED: Memoized update function to prevent unnecessary re-creations
   const updateHabitData = React.useCallback(() => {
@@ -215,10 +223,11 @@ const Dashboard = ({
       const total = getSevenDayTotal(habitData[cat.key]);
       return {
         ...cat,
-        total: total,
+        total,
+        goal: goals[cat.key],
       };
     });
-  }, [habitData]);
+  }, [habitData, goals]);
 
   const totalActions = React.useMemo(() => {
     const total = sevenDayTotals.reduce((sum, cat) => sum + cat.total, 0);
@@ -249,7 +258,24 @@ const Dashboard = ({
         </button>
       </div>
 
-      {/* Category Sections with MosaicReveal */}
+      {/* Reveal style selector */}
+      <div className="flex justify-center gap-3 mb-6">
+        {STYLE_OPTIONS.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => handleStyleChange(s.id)}
+            className={`px-5 py-2 rounded-lg font-bold text-sm transition-colors ${
+              revealStyle === s.id
+                ? "bg-yellow-400 text-black"
+                : "border border-yellow-400 text-yellow-400 hover:bg-yellow-400 hover:text-black"
+            }`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Category Sections */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
         {sevenDayTotals.map((cat) => {
           const progress = Math.min(cat.total, cat.goal);
@@ -265,19 +291,34 @@ const Dashboard = ({
                   {cat.name}
                 </h2>
                 <div className="flex justify-between items-center text-sm text-yellow-200">
-                  <span>
-                    Progress: {cat.total}/{cat.goal}
-                  </span>
+                  <span>Progress: {cat.total}/{cat.goal}</span>
                   <span>{percentage}%</span>
                 </div>
               </div>
 
               <div className="mb-4">
-                <MosaicReveal
-                  imageSrc={cat.image}
-                  filledSquares={progress}
-                  gridSize={4}
-                />
+                {revealStyle === "grid" && (
+                  <MosaicReveal
+                    imageSrc={cat.image}
+                    filledSquares={progress}
+                    gridSize={Math.ceil(Math.sqrt(cat.goal))}
+                    goal={cat.goal}
+                  />
+                )}
+                {revealStyle === "pizza" && (
+                  <PizzaReveal
+                    imageSrc={cat.image}
+                    filledSquares={progress}
+                    goal={cat.goal}
+                  />
+                )}
+                {revealStyle === "voronoi" && (
+                  <VoronoiReveal
+                    imageSrc={cat.image}
+                    filledSquares={progress}
+                    goal={cat.goal}
+                  />
+                )}
               </div>
 
               <div className="text-center">
@@ -292,6 +333,25 @@ const Dashboard = ({
                     ? "Goal achieved! 🎉"
                     : `${cat.goal - cat.total} more to reach your goal`}
                 </p>
+              </div>
+
+              <div className="mt-4">
+                <div className="flex justify-between text-xs text-yellow-400 mb-1">
+                  <span>Session blocks</span>
+                  <span className="font-bold">{cat.goal}</span>
+                </div>
+                <input
+                  type="range"
+                  min={4}
+                  max={16}
+                  value={cat.goal}
+                  onChange={(e) => handleGoalChange(cat.key, Number(e.target.value))}
+                  className="w-full accent-yellow-400"
+                />
+                <div className="flex justify-between text-xs text-yellow-700 mt-1">
+                  <span>4</span>
+                  <span>16</span>
+                </div>
               </div>
             </div>
           );
@@ -314,7 +374,7 @@ const Dashboard = ({
             <div className="text-3xl font-bold text-yellow-400">
               {Math.round(
                 (totalActions /
-                  HABIT_CATEGORIES.reduce((sum, cat) => sum + cat.goal, 0)) *
+                  sevenDayTotals.reduce((sum, cat) => sum + cat.goal, 0)) *
                   100,
               )}
               %

--- a/src/routes/Dashboard.jsx
+++ b/src/routes/Dashboard.jsx
@@ -301,7 +301,6 @@ const Dashboard = ({
                   <MosaicReveal
                     imageSrc={cat.image}
                     filledSquares={progress}
-                    gridSize={Math.ceil(Math.sqrt(cat.goal))}
                     goal={cat.goal}
                   />
                 )}

--- a/src/routes/MentalHealthTracker.jsx
+++ b/src/routes/MentalHealthTracker.jsx
@@ -1,5 +1,6 @@
 import HabitTracker from "../components/HabitTracker";
 import meditatingBee from "../assets/meditatingBee.jpg";
+import { loadGoals } from "../utils/localStorage";
 
 const mentalConfig = {
   title: "Your Mental Health Hive",
@@ -7,14 +8,21 @@ const mentalConfig = {
   entryLabel: "How many hours did you meditate or reflect?",
   placeholder: "e.g. 0.5",
   unit: "h",
-  mosaicGridSize: 4,
   clearWarning:
     "Are you sure you want to clear all your mental health data? This cannot be undone.",
   inspoQuote: "Bee Kind to Your Mind!",
 };
 
-const MentalHealthTracker = ({ entries, setEntries }) => (
-  <HabitTracker entries={entries} setEntries={setEntries} {...mentalConfig} />
-);
+const MentalHealthTracker = ({ entries, setEntries }) => {
+  const goal = loadGoals().mental;
+  return (
+    <HabitTracker
+      entries={entries}
+      setEntries={setEntries}
+      goal={goal}
+      {...mentalConfig}
+    />
+  );
+};
 
 export default MentalHealthTracker;

--- a/src/routes/PhysicalTracker.jsx
+++ b/src/routes/PhysicalTracker.jsx
@@ -1,5 +1,6 @@
 import HabitTracker from "../components/HabitTracker";
 import flashdanceBee from "../assets/flashdanceBee.jpg";
+import { loadGoals } from "../utils/localStorage";
 
 const physicalConfig = {
   title: "Your Physical Hive",
@@ -7,14 +8,21 @@ const physicalConfig = {
   entryLabel: "How many hours did you exercise?",
   placeholder: "e.g. 1.5",
   unit: "h",
-  mosaicGridSize: 4,
   clearWarning:
     "Are you sure you want to clear all your physical activity data? This cannot be undone.",
   inspoQuote: "You're Hive-ly Active!",
 };
 
-const PhysicalTracker = ({ entries, setEntries }) => (
-  <HabitTracker entries={entries} setEntries={setEntries} {...physicalConfig} />
-);
+const PhysicalTracker = ({ entries, setEntries }) => {
+  const goal = loadGoals().physical;
+  return (
+    <HabitTracker
+      entries={entries}
+      setEntries={setEntries}
+      goal={goal}
+      {...physicalConfig}
+    />
+  );
+};
 
 export default PhysicalTracker;

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -83,6 +83,42 @@ export const clearAllEntries = () => {
   clearMentalHealthEntries();
 };
 
+// Per-category session block goals
+const GOALS_KEY = "habit-hive-category-goals";
+const DEFAULT_GOALS = { coding: 16, physical: 16, mental: 16 };
+
+export const saveGoals = (goals) => {
+  try {
+    localStorage.setItem(GOALS_KEY, JSON.stringify(goals));
+  } catch (error) {
+    console.error("Failed to save goals to localStorage:", error);
+  }
+};
+
+// Reveal style preference
+const REVEAL_STYLE_KEY = "habit-hive-reveal-style";
+
+export const saveRevealStyle = (style) => {
+  try {
+    localStorage.setItem(REVEAL_STYLE_KEY, style);
+  } catch (error) {
+    console.error("Failed to save reveal style:", error);
+  }
+};
+
+export const loadRevealStyle = () =>
+  localStorage.getItem(REVEAL_STYLE_KEY) || "grid";
+
+export const loadGoals = () => {
+  try {
+    const stored = localStorage.getItem(GOALS_KEY);
+    return stored ? { ...DEFAULT_GOALS, ...JSON.parse(stored) } : { ...DEFAULT_GOALS };
+  } catch (error) {
+    console.error("Failed to load goals from localStorage:", error);
+    return { ...DEFAULT_GOALS };
+  }
+};
+
 // Get storage stats
 export const getStorageStats = () => {
   const stats = {};


### PR DESCRIPTION
##Demo
Loom Video: 
https://www.loom.com/share/97f075db97e44082b9f6f87ca43293ac

## Summary

This PR makes the Habit Hive experience personal to each user rather than 
one-size-fits-all. Users can now set their own session goal per category, 
choose how their image reveals, and the whole app stays consistent with 
those choices.

## What changed

**New reveal styles**
- Added Pizza reveal: image uncovers as pie slices, one per completed session
- Added Voronoi/Puzzle reveal: image uncovers as randomized organic shapes
- Dashboard now has a style toggle (Grid / Pizza / Puzzle) that persists 
  across sessions via localStorage

**Per-category goal setting**
- Dashboard goal slider replaces the hardcoded 16-session target
- Each category (Coding, Physical, Mental) has its own independent goal
- Goals persist across browser sessions via localStorage

**Adaptive mosaic grid**
- Grid shape is now driven by the user's goal count, not a fixed 4×4
- Max 4 tiles per row, max 4 rows, container always 1:1 square
- Fuller rows placed at top (e.g. goal=10 → [3,3,2,2])
- Eliminates the permanently dark filler tiles that appeared for non-square 
  goal numbers

**Celebration popup consistency**
- Popup now renders the same reveal style selected on the dashboard
- Progress counter shows x/[actual goal] instead of hardcoded x/16
- Tracker routes read goal from localStorage so popup and dashboard always 
  match

## Non-obvious decisions

- Mixed-row grid tiles (e.g. a 3-tile row next to a 2-tile row) have 
  slightly different widths — this is intentional. The alternative was 
  keeping dark filler tiles, which broke the reveal effect entirely.
- Reveal style and goals are read from localStorage at render time in the 
  tracker routes so they always reflect the latest Dashboard settings without 
  requiring prop drilling through App.jsx.

## Test plan
- [ ] Set goal to a non-square number (e.g. 7, 10, 13) — confirm no black 
      tiles, grid fills cleanly
- [ ] Toggle between Grid / Pizza / Puzzle on Dashboard — confirm reveal 
      updates immediately
- [ ] Log a session on any tracker page — confirm popup matches dashboard 
      style and shows correct x/goal count
- [ ] Change goal on Dashboard, navigate to tracker, log session — confirm 
      popup reflects updated goal
- [ ] Unit tests: `npm run test:unit`
